### PR TITLE
FEAT: Improve framework and add endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # pystrigo
 
+**This is WIP**. Please do not consider this to be production ready.
+
 `pystrigo` is Strigo's official Python REST API client and CLI. It allows to easily retrieve information from Strigo's REST API and to automate processes.
 
 Visit [Strigo's REST API Reference](http://docs.strigo.io/api/reference) from more information on the API and on retrieving your `ORG_ID` and `API_KEY`.
@@ -84,6 +86,10 @@ event_id = response.data['id']
 
 ### CLI
 
+`pystrigo` exposes a CLI called `siesta` (Rest. Get it? :))
+
+This CLI is supposed to provide a reasonable abstraction on top of the client, just so that it's easier to perform actions without having to write code. It is not optimized as a standard CLI in itself.
+
 ```shell
 
 $ siesta --help
@@ -91,6 +97,10 @@ Usage: siesta [OPTIONS] METHOD ENDPOINT [ARGUMENTS]...
 
 Options:
   --help  Show this message and exit.
+
+export STRIGO_ORG_ID="YOUR_ORG_ID"  # Org admins can see in settings
+export STRIGO_API_KEY="YOUR_API_KEY"  # Org admins can see in settings
+export STRIGO_API_ENDPOINT="https://app.strigo.io/api/v1"
 
 # e.g.
 $ siesta GET classes :class_id="DsAnDSjmPe2wnCRw2"
@@ -105,3 +115,6 @@ $ siesta POST events \
 ...
 ```
 
+# Contributions
+
+Any contribution is appreciated. We'd like to add tests, pytype validations, an official pypi deployment, and API documentation.

--- a/strigo/client.py
+++ b/strigo/client.py
@@ -41,10 +41,11 @@ class _HTTPClient:
     def _request(self, method, path, body=None):
         body = body or {}
         url = self.endpoint + path
-        log.debug('{} {}...'.format(method.upper(), path), **body)
-        response = getattr(requests, method)(url, data=body, headers=self.headers)
+
+        log.info('{} {}...'.format(method.upper(), path), **body)
+        response = getattr(requests, method)(url, json=body, headers=self.headers)
         if method != 'delete':
-            log.debug(
+            log.info(
                 '{} {} response'.format(method.upper(), path),
                 status_code=response.status_code,
                 data=json.dumps(json.loads(response.text), indent=4)
@@ -76,6 +77,9 @@ class Strigo:
         self.members = endpoints.Members(self._client)
         self.partners = endpoints.Partners(self._client)
         self.ondemand = endpoints.Ondemand(self._client)
+        self.resources = endpoints.Resources(self._client)
         self.workspaces = endpoints.Workspaces(self._client)
         self.enrollments = endpoints.Enrollments(self._client)
+        self.presentations = endpoints.Presentations(self._client)
         self.partner_members = endpoints.PartnerMembers(self._client)
+        self.presentation_notes = endpoints.PresentationNotes(self._client)

--- a/strigo/endpoints/enrollments.py
+++ b/strigo/endpoints/enrollments.py
@@ -4,21 +4,21 @@ from .. import utils
 class Enrollments:
     def __init__(self, client):
         self.client = client
-        self.base = '/ondemand/{}/enrollments'
+        self.base = '/ondemand/{course_id}/enrollments'
 
     def get(self, course_id, enrollment_id=None):
-        path = utils.join_url(self.base, course_id)
+        path = utils.join_url(self.base, course_id=course_id)
         if enrollment_id:
-            path = utils.join_url(self.base, course_id, enrollment_id)
+            path = utils.join_url(self.base, enrollment_id, course_id=course_id)
 
         return self.client.get(path)
 
     def post(self, course_id, body):
-        path = utils.join_url(self.base, course_id)
+        path = utils.join_url(self.base, course_id=course_id)
 
         return self.client.post(path, body=body)
 
     def delete(self, course_id, enrollment_id):
-        path = utils.join_url(self.base, course_id, enrollment_id)
+        path = utils.join_url(self.base, enrollment_id, course_id=course_id)
 
         return self.client.delete(path)

--- a/strigo/endpoints/partners.py
+++ b/strigo/endpoints/partners.py
@@ -32,19 +32,14 @@ class Partners:
 class PartnerMembers:
     def __init__(self, client):
         self.client = client
-        self.base = '/partners/{}/members'
+        self.base = '/partners/{partner_id}/members'
 
     def get(self, partner_id):
-        path = utils.join_url(self.base, partner_id)
+        path = utils.join_url(self.base, partner_id=partner_id)
 
         return self.client.get(path)
 
     def post(self, partner_id, body):
-        path = utils.join_url(self.base, partner_id)
-
-        return self.client.post(path, body=body)
-
-    def patch(self, partner_id, body):
-        path = utils.join_url(self.base, partner_id)
+        path = utils.join_url(self.base, partner_id=partner_id)
 
         return self.client.post(path, body=body)

--- a/strigo/endpoints/workspaces.py
+++ b/strigo/endpoints/workspaces.py
@@ -4,11 +4,11 @@ from .. import utils
 class Workspaces:
     def __init__(self, client):
         self.client = client
-        self.base = '/events/{}/workspaces'
+        self.base = '/events/{event_id}/workspaces'
 
     def get(self, event_id, workspace_id=None):
-        path = utils.join_url(self.base, event_id)
+        path = utils.join_url(self.base, event_id=event_id)
         if workspace_id:
-            path = utils.join_url(self.base, event_id, workspace_id)
+            path = utils.join_url(self.base, workspace_id, event_id=event_id)
 
         return self.client.get(path)

--- a/strigo/logger.py
+++ b/strigo/logger.py
@@ -1,4 +1,4 @@
 # pytype: disable=import-error
 from wryte import Wryte
 
-log = Wryte(name='strigo', level='debug', simple=True)  # pylint: disable=invalid-name
+log = Wryte(name='strigo', level='info', simple=True)  # pylint: disable=invalid-name

--- a/strigo/siesta.py
+++ b/strigo/siesta.py
@@ -1,4 +1,5 @@
 import os
+import json
 
 import click  # pytype: disable=pyi-error
 
@@ -35,8 +36,12 @@ def request(method, endpoint, arguments, verbose):
             params[key_value[0]] = key_value[1]
         elif '=' in arg:
             key_value = utils.split_kv(arg)
-            body[key_value[0]] = key_value[1]
-
+            try:
+                # Try loading JSON first
+                body[key_value[0]] = json.loads(key_value[1])
+            except (KeyError, json.decoder.JSONDecodeError):
+                # And fallback to a string.
+                body[key_value[0]] = key_value[1]
     request_endpoint = getattr(getattr(strigo, endpoint), method)
 
     try:

--- a/strigo/utils.py
+++ b/strigo/utils.py
@@ -5,11 +5,16 @@ def split_kv(pair):
     return key_value[0], key_value[1]
 
 
-def join_url(base, *args):
-    if len(args) == 2:
-        return '{}/{}'.format(base.format(args[0]), args[1])
-    if '{}' in base:
-        return base.format(args[0])
-    if len(args) == 1:
-        return '{}/{}'.format(base, args[0])
-    return base
+def join_url(base, *args, **kwargs):
+    """Returns the URL to query.
+    """
+    # Covers cases where `base` has named arguments (e.g. /events/{event_id}/workspaces),
+    # And the case where there are no arguments (e.g. /events).
+    formatted_url = base.format(**kwargs)
+    if args:
+        # This covers the case where we would like to add a parameter to the `base` after
+        # Formatting by named arguments has taken place.
+        # e.g. /events/EVENT_ID, since the base is really /events, and we need to add
+        # EVENT_ID to it somehow.
+        formatted_url = '{}/{}'.format(formatted_url, *args)
+    return formatted_url


### PR DESCRIPTION
* Fix URL joining to support unlimited URL params.
* Modify URL joining to differentiate args and kwargs for code
readability.
* Fix handling of JSON body arguments passed via the CLI. Previously, it
was sent as a string. We now attempt to read it as JSON, and fallback
to a string.
* Change default logging level to INFO.
* Change logging levels of request and response logging to INFO.
* Add class POST and PATCH endpoints.